### PR TITLE
Problem with /DescriptorCreator/PartialChargeDict.py when using Python 3.10 as the attribute MutableMapping from the module collections got moved into collections.abc**

### DIFF
--- a/DescriptorCreator/PartialChargeDict.py
+++ b/DescriptorCreator/PartialChargeDict.py
@@ -1,9 +1,14 @@
 __author__ = 'modlab'
 
-import collections
+import sys
+import collections 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 
-class PartialChargeDict(collections.MutableMapping):
+class PartialChargeDict(MutableMapping):
     """ Dictionary Decorator to store Partial Charges
 
     Class internally stores an OrderedDict with different


### PR DESCRIPTION
Problem with Python3.10 solved with this PR